### PR TITLE
Fix log injection in JSON logging formatter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,14 +61,13 @@ fn init_logs(cfg: &Config) {
         .filter_level(cfg.log_level().to_level_filter())
         .format(|buf, record| {
             use std::io::Write;
-            writeln!(
-                buf,
-                "{{\"timestamp\":\"{}\",\"level\":\"{}\",\"target\":\"{}\",\"message\":\"{}\"}}",
-                chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-                record.level(),
-                record.target(),
-                record.args()
-            )
+            let log_entry = serde_json::json!({
+                "timestamp": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                "level": record.level().to_string(),
+                "target": record.target(),
+                "message": record.args().to_string(),
+            });
+            writeln!(buf, "{}", log_entry)
         })
         .init();
 }


### PR DESCRIPTION
## Summary

- Use `serde_json::json!()` macro to properly escape user-controlled data in structured log output
- Prevents log injection attacks where crafted namespace/flag names could break JSON log structure

Closes #97

## Test plan

- [ ] Verify JSON logging output is valid JSON when flag names contain special characters (quotes, backslashes, newlines)
- [ ] Verify normal logging still works correctly